### PR TITLE
Add lubridate to required packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ Depends:
     foreach,
     rgdal,
     gdalUtils,
+    lubridate
 Suggests:
     robustbase,
     ranger


### PR DESCRIPTION
Trying to install the package fails with:
```
Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) :
  there is no package called ‘lubridate’
```
This patch adds lubridate to required packages to fix that error.